### PR TITLE
fix(cicd): Github token vs Org PAT

### DIFF
--- a/.github/workflows/pr_author_update.yml
+++ b/.github/workflows/pr_author_update.yml
@@ -27,14 +27,14 @@ jobs:
 
     - name: Run AUTHORS update script
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_USER: ${{ github.event.pull_request.user.login }}
       run: python .github/scripts/update_authors.py
 
     - name: Commit and push changes
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Github Token's cannot write within the same repository and action, so we are going to use an Organizational PAT - I Generated it and handed off ownership, so technically everyone should be able to use the PAT in the workspace.